### PR TITLE
use IMDSv2 instance metadata curl method

### DIFF
--- a/rama-cluster/supervisor/start.sh
+++ b/rama-cluster/supervisor/start.sh
@@ -2,14 +2,15 @@
 
 mv /run/rama/rama.yaml /data/rama/rama.yaml
 
-PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
-PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+PRIVATE_IP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)
+PUBLIC_IP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4)
 
 cat <<EOF >> /data/rama/rama.yaml
 
 supervisor.host:
-  external: $PUBLIC_IP
-  internal: $PRIVATE_IP
+  external: "$PUBLIC_IP"
+  internal: "$PRIVATE_IP"
 EOF
 
 systemctl enable supervisor.service


### PR DESCRIPTION
On an `eu-central-1` supervisor EC2 machine, we found that calling `curl http://169.254.169.254/latest/meta-data` returns a `401 Unauthorized` response.  This is somewhat unexpected, however on the [AWS documentation page](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html) they provide an alternate method "IMDSv2" where a token is retrieved first, then used to get latest metadata.

This fixed the retrieval and returns the correct public and private IP addresses for `supervisor.host`.