### PR TITLE
Package manager command option

### DIFF
--- a/rama-cluster/cluster.tf
+++ b/rama-cluster/cluster.tf
@@ -139,6 +139,7 @@ data "cloudinit_config" "conductor_config" {
     content_type = "text/x-shellscript"
     content = templatefile("setup-disks.sh", {
       username = var.username
+      package_manager_command = var.package_manager_command
     })
   }
 
@@ -225,6 +226,7 @@ data "cloudinit_config" "supervisor_config" {
     content_type = "text/x-shellscript"
     content = templatefile("setup-disks.sh", {
       username = var.username
+      package_manager_command = var.package_manager_command
     })
   }
 
@@ -316,6 +318,7 @@ resource "null_resource" "zookeeper" {
 
   provisioner "remote-exec" {
     inline = [
+      "export PACKAGE_MANAGER_COMMAND=${var.package_manager_command}",
       "chmod +x ${local.home_dir}/setup.sh",
       "${local.home_dir}/setup.sh ${var.zookeeper_url}"
     ]
@@ -338,8 +341,17 @@ resource "null_resource" "zookeeper" {
     destination = "${local.home_dir}/zookeeper/data/myid"
   }
 
+  provisioner "file" {
+    source      = "zookeeper/start.sh"
+    destination = "${local.home_dir}/start.sh"
+  }
+
   provisioner "remote-exec" {
-    script = "zookeeper/start.sh"
+    inline = [
+      "export PACKAGE_MANAGER_COMMAND=${var.package_manager_command}",
+      "chmod +x ${local.home_dir}/start.sh",
+      "${local.home_dir}/start.sh"
+    ]
   }
 }
 

--- a/rama-cluster/cluster.tf
+++ b/rama-cluster/cluster.tf
@@ -49,6 +49,16 @@ variable "private_ssh_key" {
   default = null
 }
 
+variable "package_manager_command" {
+  type = string
+  default = "yum"
+
+  validation {
+    condition = contains(["yum", "apt-get"], var.package_manager_command)
+    error_message = "Only yum and apt-get are accepted"
+  }
+}
+
 provider "aws" {
   region      = var.region
   max_retries = 25

--- a/rama-cluster/setup-disks.sh
+++ b/rama-cluster/setup-disks.sh
@@ -2,7 +2,7 @@
 
 # This is intended to be run as root - user data scripts are run as such automatically
 
-yum -y install nvme-cli
+${package_manager_command} -y install nvme-cli
 
 DEVICE=`nvme list | grep "Instance Storage" | awk '{print $1}'`
 

--- a/rama-cluster/zookeeper/setup.sh
+++ b/rama-cluster/zookeeper/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo yum update -y
+sudo ${PACKAGE_MANAGER_COMMAND} update -y
 
 echo "Downloading zookeeper..." >> setup.log
 

--- a/rama-cluster/zookeeper/start.sh
+++ b/rama-cluster/zookeeper/start.sh
@@ -1,6 +1,6 @@
 ##!/bin/bash
 
-sudo yum update -y
+sudo ${PACKAGE_MANAGER_COMMAND} update -y
 
 echo "Starting zookeeper..." >> setup.log
 


### PR DESCRIPTION
Some linux distribution doesn't have the `yum` command. This PR allow the user to override the default command (`yum`).
An other option is to force the user to have the right linux distribution (in this case, we should explain this in the `AMI requirement` section).

resolve #4 