### PR TITLE
changed zookeper.servers hostname to private ip

### DIFF
--- a/rama-cluster/single/cloud-config.yaml
+++ b/rama-cluster/single/cloud-config.yaml
@@ -1,11 +1,5 @@
 #cloud-config
 write_files:
-# files for all
-  - path: /run/rama/rama.yaml
-    content: ${base64encode(rama_yaml_contents)}
-    encoding: b64
-    owner: ${username}:${username}
-
 # files for supervisor
   - path: ${supervisor_service_file_destination}
     content: ${base64encode(supervisor_service_file_contents)}

--- a/rama-cluster/single/main.tf
+++ b/rama-cluster/single/main.tf
@@ -131,9 +131,6 @@ data "cloudinit_config" "rama_config" {
 	content = templatefile("./cloud-config.yaml", {
 	  username = var.username,
 
-	  # rama.yaml
-	  rama_yaml_contents = templatefile("./rama.yaml", {}),
-
 	  # conductor.service
 	  conductor_service_name = "conductor",
 	  conductor_service_file_destination = "${local.systemd_dir}/conductor.service",
@@ -199,6 +196,13 @@ resource "null_resource" "rama" {
 	destination = "${local.home_dir}/zookeeper/data/myid"
   }
 
+  provisioner "file" {
+	content = templatefile("./rama.yaml", {
+	  zk_private_ip = aws_instance.rama.private_ip
+	})
+	destination = "/tmp/rama.yaml"
+  }
+
   provisioner "remote-exec" {
     script = "./start.sh"
   }
@@ -220,7 +224,7 @@ resource "null_resource" "local" {
         conductor_public_ip  = aws_instance.rama.public_ip
         conductor_private_ip = aws_instance.rama.private_ip
       })
-    )
+      )
   }
 }
 

--- a/rama-cluster/single/rama.yaml
+++ b/rama-cluster/single/rama.yaml
@@ -1,6 +1,3 @@
-# put custom rama.yaml here
-# conductor.host and zookeeper.servers will be added automatically
-
 supervisor.port.range:
   - 20000
   - 21000
@@ -11,7 +8,7 @@ worker.child.opts: "-Xms8192m -Xmx8192m -Xmn4096m -XX:SurvivorRatio=4 -XX:MaxTen
 local.dir: "local-rama-data"
 
 zookeeper.servers:
-  - "localhost"
+  - "${ zk_private_ip }"
 
 conductor.host: "localhost"
 supervisor.host: "localhost"

--- a/rama-cluster/single/start.sh
+++ b/rama-cluster/single/start.sh
@@ -24,7 +24,7 @@ done
 
 
 # -f and sudo because we must override the rama.yaml that comes from extracting rama.zip
-sudo mv -f /run/rama/rama.yaml /data/rama/rama.yaml
+sudo mv -f /tmp/rama.yaml /data/rama/rama.yaml
 
 cd /data/rama
 


### PR DESCRIPTION
now the zookeeper's hostname is the private ip. required switching some things around in the dependency graph. tested that singleNode deploy works and logging module is able to be deployed to it