### PR TITLE
conductor and supervisor use private ip

### DIFF
--- a/rama-cluster/single/main.tf
+++ b/rama-cluster/single/main.tf
@@ -199,6 +199,8 @@ resource "null_resource" "rama" {
   provisioner "file" {
 	content = templatefile("./rama.yaml", {
 	  zk_private_ip = aws_instance.rama.private_ip
+	  conductor_private_ip = aws_instance.rama.private_ip
+	  supervisor_private_ip = aws_instance.rama.private_ip
 	})
 	destination = "/tmp/rama.yaml"
   }

--- a/rama-cluster/single/rama.yaml
+++ b/rama-cluster/single/rama.yaml
@@ -10,5 +10,5 @@ local.dir: "local-rama-data"
 zookeeper.servers:
   - "${ zk_private_ip }"
 
-conductor.host: "localhost"
-supervisor.host: "localhost"
+conductor.host: "${ conductor_private_ip }"
+supervisor.host: "${ supervisor_private_ip }"


### PR DESCRIPTION
tested by deploying a singleNode cluster and deploying monitoring module to it successfully.