### PR TITLE
feat: instance storage fix and single-node improvements

### DIFF
--- a/bin/rama-cluster.sh
+++ b/bin/rama-cluster.sh
@@ -21,7 +21,7 @@ if [[ "$1" == "--singleNode" ]]; then
 	shift
 fi
 
-	
+
 [[ $# -ge 1 ]] || usage
 
 CLUSTER_NAME=$1

--- a/rama-cluster/common/conductor/unpack-rama.sh
+++ b/rama-cluster/common/conductor/unpack-rama.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-sudo mv /home/${username}/rama.zip /data/rama
 cd /data/rama
 
 sudo unzip -n rama.zip

--- a/rama-cluster/common/setup-disks.sh
+++ b/rama-cluster/common/setup-disks.sh
@@ -15,7 +15,7 @@ if [ ! -z $DEVICE ] ; then
 fi
 
 USERNAME='${username}'
-if [ "$USERNAME" = '${username}' ]; then 
+if [ "$USERNAME" = '${username}' ]; then
   USERNAME="$1"
 fi
 

--- a/rama-cluster/common/zookeeper/setup.sh
+++ b/rama-cluster/common/zookeeper/setup.sh
@@ -1,23 +1,63 @@
 #!/bin/bash
+set -e  # Exit on error
+
+echo "Installing Java (required for Zookeeper and Rama)..."
+sudo yum install -y java-21-amazon-corretto
+
+echo "Verifying Java installation..."
+java -version
 
 sudo yum update -y
 
-echo "Downloading zookeeper..." >> setup.log
+echo "Downloading zookeeper from $1..."
 
-# Download and unpack Zookeeper
-wget $1 -O zookeeper.tar.gz -o setup.log
+# Download Zookeeper using curl (curl is required per AMI requirements)
+# -L follows redirects, -f fails on HTTP errors
+if ! curl -L -f -o zookeeper.tar.gz "$1"; then
+  echo "Failed to download zookeeper from $1"
+  exit 1
+fi
+
+echo "Download complete ($(wc -c < zookeeper.tar.gz) bytes)"
+
+# Verify it's actually a gzip file
+if ! file zookeeper.tar.gz | grep -q "gzip"; then
+  echo "Error: Downloaded file is not a gzip archive:"
+  file zookeeper.tar.gz
+  echo "First 500 bytes of file:"
+  head -c 500 zookeeper.tar.gz
+  exit 1
+fi
+
+echo "File verified as gzip, extracting..."
 
 # Extract zookeeper tar into a temporary directory
-mkdir tmp && tar zxvf zookeeper.tar.gz -C tmp &>> setup.log
+mkdir -p tmp
+if ! tar zxf zookeeper.tar.gz -C tmp; then
+  echo "Failed to extract zookeeper.tar.gz"
+  ls -la zookeeper.tar.gz
+  exit 1
+fi
 
-# Then move everything out of the top-level directory in tmp, into a zookeeper
-# directory. Since we don't know the name of the file this is going to be, we
-# can't just do a more straight fowards rename without isolating the file into
-# it's own directory first.
-mv tmp/* zookeeper
-rm -rf tmp # then we clean up the now empty temporary directory
+echo "Extraction complete, contents of tmp:"
+ls -la tmp/
 
-echo "Successfully downloaded Zookeeper" >> setup.log
+# Move the extracted directory to zookeeper
+# The tar extracts to tmp/apache-zookeeper-X.X.X-bin/
+# Find the directory and rename it to zookeeper
+ZOOKEEPER_DIR=$(ls tmp/)
+if [ -z "$ZOOKEEPER_DIR" ]; then
+  echo "Error: No directory found in tmp/"
+  exit 1
+fi
 
-mkdir zookeeper/data
-mkdir zookeeper/logs
+mv "tmp/$ZOOKEEPER_DIR" zookeeper
+rm -rf tmp
+
+echo "Successfully set up Zookeeper at: $(pwd)/zookeeper"
+
+# Create data and logs directories
+mkdir -p zookeeper/data
+mkdir -p zookeeper/logs
+
+echo "Zookeeper setup complete"

--- a/rama-cluster/multi/cluster.tf
+++ b/rama-cluster/multi/cluster.tf
@@ -360,6 +360,13 @@ resource "null_resource" "zookeeper" {
 # TODO find some way to include all ZK ip addresses :(
 ###
 resource "null_resource" "local" {
+  depends_on = [aws_instance.conductor, aws_instance.zookeeper]
+
+  triggers = {
+    conductor_id = aws_instance.conductor.id
+    zookeeper_ids = join(",", aws_instance.zookeeper[*].id)
+  }
+
   # Render to local file on machine
   # https://github.com/hashicorp/terraform/issues/8090#issuecomment-291823613
   provisioner "local-exec" {

--- a/rama-cluster/multi/cluster.tf
+++ b/rama-cluster/multi/cluster.tf
@@ -13,10 +13,20 @@ variable "key_name" { type = string }     # from ~/.rama/auth.tfvars
 variable "username" { type = string }
 variable "vpc_security_group_ids" { type = list(string) }
 
-variable "rama_source_path" { type = string }
+variable "rama_source_path" {
+  type = string
+  validation {
+    condition     = fileexists(var.rama_source_path)
+    error_message = "The rama_source_path file does not exist: ${var.rama_source_path}"
+  }
+}
 variable "license_source_path" {
   type    = string
   default = ""
+  validation {
+    condition     = var.license_source_path == "" || fileexists(var.license_source_path)
+    error_message = "The license_source_path file does not exist: ${var.license_source_path}"
+  }
 }
 variable "zookeeper_url" { type = string }
 
@@ -50,6 +60,10 @@ variable "use_private_ip" {
 variable "private_ssh_key" {
   type    = string
   default = null
+  validation {
+    condition     = var.private_ssh_key == null || fileexists(var.private_ssh_key)
+    error_message = "The private_ssh_key file does not exist: ${var.private_ssh_key}"
+  }
 }
 
 provider "aws" {

--- a/rama-cluster/multi/conductor/cloud-config.yaml
+++ b/rama-cluster/multi/conductor/cloud-config.yaml
@@ -17,7 +17,3 @@ write_files:
     encoding: b64
     owner: ${username}:${username}
 %{ endif }
-  - path: /data/rama/unpack-rama.sh
-    content: ${base64encode(unpack_rama_contents)}
-    encoding: b64
-    owner: ${username}:${username}

--- a/rama-cluster/single/cloud-config.yaml
+++ b/rama-cluster/single/cloud-config.yaml
@@ -17,7 +17,3 @@ write_files:
     encoding: b64
     owner: ${username}:${username}
 %{ endif }
-  - path: /data/rama/unpack-rama.sh
-    content: ${base64encode(unpack_rama_contents)}
-    encoding: b64
-    owner: ${username}:${username}

--- a/rama-cluster/single/main.tf
+++ b/rama-cluster/single/main.tf
@@ -14,10 +14,20 @@ variable "key_name" { type = string }     # from ~/.rama/auth.tfvars
 variable "username" { type = string }
 variable "vpc_security_group_ids" { type = list(string) }
 
-variable "rama_source_path" { type = string }
+variable "rama_source_path" {
+  type = string
+  validation {
+    condition     = fileexists(var.rama_source_path)
+    error_message = "The rama_source_path file does not exist: ${var.rama_source_path}"
+  }
+}
 variable "license_source_path" {
   type    = string
   default = ""
+  validation {
+    condition     = var.license_source_path == "" || fileexists(var.license_source_path)
+    error_message = "The license_source_path file does not exist: ${var.license_source_path}"
+  }
 }
 variable "zookeeper_url" { type = string }
 
@@ -38,6 +48,10 @@ variable "use_private_ip" {
 variable "private_ssh_key" {
   type    = string
   default = null
+  validation {
+    condition     = var.private_ssh_key == null || fileexists(var.private_ssh_key)
+    error_message = "The private_ssh_key file does not exist: ${var.private_ssh_key}"
+  }
 }
 
 provider "aws" {

--- a/rama-cluster/single/main.tf
+++ b/rama-cluster/single/main.tf
@@ -37,7 +37,10 @@ variable "ami_id" {
 }
 
 variable "instance_type" { type = string }
-variable "instance_profile" { type = string }
+variable "instance_profile" {
+  type    = string
+  default = null
+}
 
 variable "volume_size_gb" {
   type    = number

--- a/rama-cluster/single/main.tf
+++ b/rama-cluster/single/main.tf
@@ -38,6 +38,7 @@ variable "ami_id" {
 }
 
 variable "instance_type" { type = string }
+variable "instance_profile" { type = string }
 
 variable "volume_size_gb" {
   type    = number
@@ -101,6 +102,7 @@ resource "aws_instance" "rama" {
   instance_type = var.instance_type
   # subnet_id              = local.subnet_id
   vpc_security_group_ids = local.vpc_security_group_ids
+  iam_instance_profile   = var.instance_profile
   key_name               = var.key_name
 
   user_data = data.cloudinit_config.rama_config.rendered

--- a/rama-cluster/single/main.tf
+++ b/rama-cluster/single/main.tf
@@ -247,6 +247,12 @@ resource "null_resource" "rama" {
 # Setup local to allow `rama-my-cluster` commands
 ###
 resource "null_resource" "local" {
+  depends_on = [null_resource.rama]
+
+  triggers = {
+    instance_id = aws_instance.rama.id
+  }
+
   # Render to local file on machine
   # https://github.com/hashicorp/terraform/issues/8090#issuecomment-291823613
   provisioner "local-exec" {


### PR DESCRIPTION
## Summary

- Fix race condition where cloud-init writes files to `/data/rama` before instance storage is mounted
- Add `instance_profile` variable for single-node deployments
- Default `ami_id` to latest Amazon Linux 2023 ARM64 via SSM Parameter Store
- Add file path validations for early failure on missing files
- Improve zookeeper setup script reliability

## Test plan

- [ ] Deploy single-node cluster with instance storage
- [ ] Verify rama.zip and unpack-rama.sh are properly uploaded after disk mount
- [ ] Test with and without explicit `ami_id`
- [ ] Verify `instance_profile` is attached to EC2 instance